### PR TITLE
Pass service token to dataset client

### DIFF
--- a/errors/errorstest/message_producer.go
+++ b/errors/errorstest/message_producer.go
@@ -8,7 +8,6 @@ import (
 )
 
 var (
-	lockMessageProducerMockCloser sync.RWMutex
 	lockMessageProducerMockOutput sync.RWMutex
 )
 
@@ -18,9 +17,6 @@ var (
 //
 //         // make and configure a mocked MessageProducer
 //         mockedMessageProducer := &MessageProducerMock{
-//             CloserFunc: func() chan bool {
-// 	               panic("TODO: mock out the Closer method")
-//             },
 //             OutputFunc: func() chan []byte {
 // 	               panic("TODO: mock out the Output method")
 //             },
@@ -31,47 +27,15 @@ var (
 //
 //     }
 type MessageProducerMock struct {
-	// CloserFunc mocks the Closer method.
-	CloserFunc func() chan bool
-
 	// OutputFunc mocks the Output method.
 	OutputFunc func() chan []byte
 
 	// calls tracks calls to the methods.
 	calls struct {
-		// Closer holds details about calls to the Closer method.
-		Closer []struct {
-		}
 		// Output holds details about calls to the Output method.
 		Output []struct {
 		}
 	}
-}
-
-// Closer calls CloserFunc.
-func (mock *MessageProducerMock) Closer() chan bool {
-	if mock.CloserFunc == nil {
-		panic("moq: MessageProducerMock.CloserFunc is nil but MessageProducer.Closer was just called")
-	}
-	callInfo := struct {
-	}{}
-	lockMessageProducerMockCloser.Lock()
-	mock.calls.Closer = append(mock.calls.Closer, callInfo)
-	lockMessageProducerMockCloser.Unlock()
-	return mock.CloserFunc()
-}
-
-// CloserCalls gets all the calls that were made to Closer.
-// Check the length with:
-//     len(mockedMessageProducer.CloserCalls())
-func (mock *MessageProducerMock) CloserCalls() []struct {
-} {
-	var calls []struct {
-	}
-	lockMessageProducerMockCloser.RLock()
-	calls = mock.calls.Closer
-	lockMessageProducerMockCloser.RUnlock()
-	return calls
 }
 
 // Output calls OutputFunc.

--- a/event/eventtest/datasetapi.go
+++ b/event/eventtest/datasetapi.go
@@ -18,7 +18,7 @@ var (
 //
 //         // make and configure a mocked DatasetAPI
 //         mockedDatasetAPI := &DatasetAPIMock{
-//             PutVersionFunc: func(id string, edition string, version string, m dataset.Version) error {
+//             PutVersionFunc: func(id string, edition string, version string, m dataset.Version, config ...dataset.Config) error {
 // 	               panic("TODO: mock out the PutVersion method")
 //             },
 //         }
@@ -29,7 +29,7 @@ var (
 //     }
 type DatasetAPIMock struct {
 	// PutVersionFunc mocks the PutVersion method.
-	PutVersionFunc func(id string, edition string, version string, m dataset.Version) error
+	PutVersionFunc func(id string, edition string, version string, m dataset.Version, config ...dataset.Config) error
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -43,12 +43,14 @@ type DatasetAPIMock struct {
 			Version string
 			// M is the m argument value.
 			M dataset.Version
+			// Config is the config argument value.
+			Config []dataset.Config
 		}
 	}
 }
 
 // PutVersion calls PutVersionFunc.
-func (mock *DatasetAPIMock) PutVersion(id string, edition string, version string, m dataset.Version) error {
+func (mock *DatasetAPIMock) PutVersion(id string, edition string, version string, m dataset.Version, config ...dataset.Config) error {
 	if mock.PutVersionFunc == nil {
 		panic("moq: DatasetAPIMock.PutVersionFunc is nil but DatasetAPI.PutVersion was just called")
 	}
@@ -57,16 +59,18 @@ func (mock *DatasetAPIMock) PutVersion(id string, edition string, version string
 		Edition string
 		Version string
 		M       dataset.Version
+		Config  []dataset.Config
 	}{
 		Id:      id,
 		Edition: edition,
 		Version: version,
 		M:       m,
+		Config:  config,
 	}
 	lockDatasetAPIMockPutVersion.Lock()
 	mock.calls.PutVersion = append(mock.calls.PutVersion, callInfo)
 	lockDatasetAPIMockPutVersion.Unlock()
-	return mock.PutVersionFunc(id, edition, version, m)
+	return mock.PutVersionFunc(id, edition, version, m, config...)
 }
 
 // PutVersionCalls gets all the calls that were made to PutVersion.
@@ -77,12 +81,14 @@ func (mock *DatasetAPIMock) PutVersionCalls() []struct {
 	Edition string
 	Version string
 	M       dataset.Version
+	Config  []dataset.Config
 } {
 	var calls []struct {
 		Id      string
 		Edition string
 		Version string
 		M       dataset.Version
+		Config  []dataset.Config
 	}
 	lockDatasetAPIMockPutVersion.RLock()
 	calls = mock.calls.PutVersion

--- a/event/handler_test.go
+++ b/event/handler_test.go
@@ -13,8 +13,11 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-const filterOutputId = "345"
-const fileUrl = "s3://some/url/123.csv"
+const (
+	filterOutputId = "345"
+	fileUrl        = "s3://some/url/123.csv"
+	ServiceToken   = "gravy"
+)
 
 var filterOutputEvent = &event.FilterSubmitted{FilterID: filterOutputId}
 
@@ -25,6 +28,10 @@ var filter = &observation.Filter{
 		{Name: "age", Options: []string{"29", "30"}},
 		{Name: "sex", Options: []string{"male", "female"}},
 	},
+}
+
+var cfg = dataset.Config{
+	AuthToken: ServiceToken,
 }
 
 func TestExportHandler_Handle_FilterStoreGetError(t *testing.T) {
@@ -40,7 +47,7 @@ func TestExportHandler_Handle_FilterStoreGetError(t *testing.T) {
 			},
 		}
 
-		handler := event.NewExportHandler(mockFilterStore, nil, nil, nil, datasetAPIMock)
+		handler := event.NewExportHandler(mockFilterStore, nil, nil, nil, datasetAPIMock, cfg.AuthToken)
 
 		Convey("When handle is called", func() {
 
@@ -72,7 +79,7 @@ func TestExportHandler_Handle_ObservationStoreError(t *testing.T) {
 			},
 		}
 
-		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, nil, nil, nil)
+		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, nil, nil, nil, cfg.AuthToken)
 
 		Convey("When handle is called", func() {
 
@@ -119,7 +126,7 @@ func TestExportHandler_Handle_FileStoreError(t *testing.T) {
 			},
 		}
 
-		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, nil, nil)
+		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, nil, nil, cfg.AuthToken)
 
 		Convey("When handle is called", func() {
 
@@ -167,7 +174,7 @@ func TestExportHandler_Handle_Empty_Results(t *testing.T) {
 			},
 		}
 
-		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, nil, nil)
+		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, nil, nil, cfg.AuthToken)
 
 		Convey("When handle is called", func() {
 
@@ -215,7 +222,7 @@ func TestExportHandler_Handle_Instance_Not_Found(t *testing.T) {
 			},
 		}
 
-		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, nil, nil)
+		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, nil, nil, cfg.AuthToken)
 
 		Convey("When handle is called", func() {
 
@@ -262,7 +269,7 @@ func TestExportHandler_Handle_FilterStorePutError(t *testing.T) {
 			},
 		}
 
-		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, nil, nil)
+		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, nil, nil, cfg.AuthToken)
 
 		Convey("When handle is called", func() {
 
@@ -318,7 +325,7 @@ func TestExportHandler_Handle_EventProducerError(t *testing.T) {
 			},
 		}
 
-		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, mockedEventProducer, nil)
+		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, mockedEventProducer, nil, cfg.AuthToken)
 
 		Convey("When handle is called", func() {
 
@@ -372,7 +379,7 @@ func TestExportHandler_Handle(t *testing.T) {
 			},
 		}
 
-		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, mockedEventProducer, nil)
+		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, mockedEventProducer, nil, cfg.AuthToken)
 
 		Convey("When handle is called", func() {
 
@@ -456,7 +463,7 @@ func TestExportHandler_HandlePrePublish(t *testing.T) {
 			return nil, mockErr
 		}
 
-		handler := event.NewExportHandler(filterStoreMock, observationStoreMock, fileStockMock, producerMock, datasetApiMock)
+		handler := event.NewExportHandler(filterStoreMock, observationStoreMock, fileStockMock, producerMock, datasetApiMock, cfg.AuthToken)
 
 		Convey("when handle is called", func() {
 			err := handler.Handle(e)
@@ -490,7 +497,7 @@ func TestExportHandler_HandlePrePublish(t *testing.T) {
 			return "", mockErr
 		}
 
-		handler := event.NewExportHandler(filterStoreMock, observationStoreMock, fileStockMock, producerMock, datasetApiMock)
+		handler := event.NewExportHandler(filterStoreMock, observationStoreMock, fileStockMock, producerMock, datasetApiMock, cfg.AuthToken)
 
 		Convey("when handle is called", func() {
 			err := handler.Handle(e)
@@ -528,7 +535,7 @@ func TestExportHandler_HandlePrePublish(t *testing.T) {
 			return "/url", nil
 		}
 
-		datasetApiMock.PutVersionFunc = func(id string, edition string, version string, m dataset.Version) error {
+		datasetApiMock.PutVersionFunc = func(id string, edition string, version string, m dataset.Version, cfg ...dataset.Config) error {
 			return nil
 		}
 
@@ -536,7 +543,7 @@ func TestExportHandler_HandlePrePublish(t *testing.T) {
 			return nil
 		}
 
-		handler := event.NewExportHandler(filterStoreMock, observationStoreMock, fileStockMock, producerMock, datasetApiMock)
+		handler := event.NewExportHandler(filterStoreMock, observationStoreMock, fileStockMock, producerMock, datasetApiMock, cfg.AuthToken)
 
 		Convey("when handle is called", func() {
 			err := handler.Handle(e)
@@ -577,7 +584,7 @@ func TestExportHandler_HandlePrePublish(t *testing.T) {
 			return "/url", nil
 		}
 
-		datasetApiMock.PutVersionFunc = func(id string, edition string, version string, m dataset.Version) error {
+		datasetApiMock.PutVersionFunc = func(id string, edition string, version string, m dataset.Version, cfg ...dataset.Config) error {
 			return mockErr
 		}
 
@@ -585,7 +592,7 @@ func TestExportHandler_HandlePrePublish(t *testing.T) {
 			return nil
 		}
 
-		handler := event.NewExportHandler(filterStoreMock, observationStoreMock, fileStockMock, producerMock, datasetApiMock)
+		handler := event.NewExportHandler(filterStoreMock, observationStoreMock, fileStockMock, producerMock, datasetApiMock, cfg.AuthToken)
 
 		Convey("when handle is called", func() {
 			err := handler.Handle(e)

--- a/vendor/github.com/ONSdigital/go-ns/clients/dataset/data.go
+++ b/vendor/github.com/ONSdigital/go-ns/clients/dataset/data.go
@@ -36,15 +36,20 @@ type Version struct {
 	CollectionID  string              `json:"collection_id"`
 	Downloads     map[string]Download `json:"downloads"`
 	Edition       string              `json:"edition"`
+	Dimensions    []Dimension         `json:"dimensions"`
 	ID            string              `json:"id"`
 	InstanceID    string              `json:"instance_id"`
 	LatestChanges []Change            `json:"latest_changes"`
-	License       string              `json:"license"`
 	Links         Links               `json:"links"`
 	ReleaseDate   string              `json:"release_date"`
-	State         string              `json:"date"`
+	State         string              `json:"state"`
 	Temporal      []Temporal          `json:"temporal"`
 	Version       int                 `json:"version"`
+}
+
+// Instance represents an instance within a dataset
+type Instance struct {
+	Version
 }
 
 // Metadata is a combination of version and dataset model fields
@@ -55,8 +60,10 @@ type Metadata struct {
 
 // Download represents a version download from the dataset api
 type Download struct {
-	URL  string `json:"url"`
-	Size string `json:"size"`
+	URL     string `json:"url"`
+	Size    string `json:"size"`
+	Public  string `json:"public,omitempty"`
+	Private string `json:"private,omitempty"`
 }
 
 // Edition represents an edition within a dataset
@@ -147,6 +154,7 @@ type Dimension struct {
 	ID          string `json:"dimension"`
 	Links       Links  `json:"links"`
 	Description string `json:"description"`
+	Label       string `json:"label"`
 }
 
 // Options represents a list of options from the dataset api
@@ -222,9 +230,14 @@ func (m Metadata) String() string {
 	}
 	b.WriteString(fmt.Sprintf("Latest Changes: %s\n", m.LatestChanges))
 	b.WriteString(fmt.Sprintf("Periodicity: %s\n", m.ReleaseFrequency))
-	b.WriteString(fmt.Sprintf("Distribution: %s\n", m.Downloads))
+	b.WriteString("Distribution:\n")
+	for k, v := range m.Downloads {
+		b.WriteString(fmt.Sprintf("\tExtension: %s\n", k))
+		b.WriteString(fmt.Sprintf("\tSize: %s\n", v.Size))
+		b.WriteString(fmt.Sprintf("\tURL: %s\n\n", v.URL))
+	}
 	b.WriteString(fmt.Sprintf("Unit of measure: %s\n", m.UnitOfMeasure))
-	b.WriteString(fmt.Sprintf("License: %s\n", m.Model.License))
+	b.WriteString(fmt.Sprintf("License: %s\n", m.License))
 	b.WriteString(fmt.Sprintf("Methodologies: %s\n", m.Methodologies))
 	b.WriteString(fmt.Sprintf("National Statistic: %t\n", m.NationalStatistic))
 	b.WriteString(fmt.Sprintf("Publications: %s\n", m.Publications))

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -21,10 +21,10 @@
 			"revisionTime": "2017-12-21T09:34:27Z"
 		},
 		{
-			"checksumSHA1": "pntBePgosxS/wRKlWMQzbtmwcE0=",
+			"checksumSHA1": "zt4AInA1RMIfycBvLcJv+DDqXRs=",
 			"path": "github.com/ONSdigital/go-ns/clients/dataset",
-			"revision": "02d3d2f2e96f4d8583192a90d6c8e6932d8ff7b6",
-			"revisionTime": "2017-12-21T09:34:27Z"
+			"revision": "b7c32727ee0de2d1e987539302b141890d287b6a",
+			"revisionTime": "2018-04-04T08:55:37Z"
 		},
 		{
 			"checksumSHA1": "14UTvxZ+UDwGqWbmO4jmojzzIUM=",


### PR DESCRIPTION
### What

When updating a version document with downloads via the dataset API,
send the service auth token to the dataset client which will set
the authorization header to be this token.

### How to review

Check logic makes sense and tests pass

### Who can review

Team B
