### PR TITLE
Apply configured prefixes for s3 filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ environment variables, or with a link to a configuration guide.
 | ZEBEDEE_URL                 | http://localhost:8082                | The URL to zebedee
 | AWS_ACCESS_KEY_ID           | -                                    | The AWS access key credential
 | AWS_SECRET_ACCESS_KEY       | -                                    | The AWS secret key credential
+| FULL_DATASET_FILE_PREFIX    | full-datasets                        | The prefix added to full dataset download files
+| FILTERED_DATASET_FILE_PREFIX| filtered-dataset                     | The prefix added to filtered dataset download files
 
 ### Healthcheck
 

--- a/cmd/dp-dataset-exporter/main.go
+++ b/cmd/dp-dataset-exporter/main.go
@@ -69,14 +69,30 @@ func main() {
 
 	filterStore := filter.NewStore(cfg.FilterAPIURL, cfg.FilterAPIAuthToken, cfg.ServiceAuthToken, &httpClient)
 	observationStore := observation.NewStore(neo4jConnPool)
-	fileStore, err := file.NewStore(cfg.AWSRegion, cfg.S3BucketName, cfg.S3PrivateBucketName, cfg.VaultPath, vaultClient)
+
+	fileStore, err := file.NewStore(
+		cfg.AWSRegion,
+		cfg.S3BucketName,
+		cfg.S3PrivateBucketName,
+		cfg.VaultPath,
+		vaultClient)
 	exitIfError(err)
+
 	eventProducer := event.NewAvroProducer(kafkaProducer, schema.CSVExportedEvent)
 
 	datasetAPICli := dataset.New(cfg.DatasetAPIURL)
 	datasetAPICli.SetInternalToken(cfg.DatasetAPIAuthToken)
 
-	eventHandler := event.NewExportHandler(filterStore, observationStore, fileStore, eventProducer, datasetAPICli, cfg.ServiceAuthToken, cfg.DownloadServiceURL)
+	eventHandler := event.NewExportHandler(
+		filterStore,
+		observationStore,
+		fileStore,
+		eventProducer,
+		datasetAPICli,
+		cfg.ServiceAuthToken,
+		cfg.DownloadServiceURL,
+		cfg.FullDatasetFilePrefix,
+		cfg.FilteredDatasetFilePrefix)
 
 	isReady := make(chan bool)
 

--- a/config/config.go
+++ b/config/config.go
@@ -9,58 +9,62 @@ import (
 
 // Config values for the application.
 type Config struct {
-	BindAddr                 string        `envconfig:"BIND_ADDR"`
-	KafkaAddr                []string      `envconfig:"KAFKA_ADDR"`
-	FilterConsumerGroup      string        `envconfig:"FILTER_JOB_CONSUMER_GROUP"`
-	FilterConsumerTopic      string        `envconfig:"FILTER_JOB_CONSUMER_TOPIC"`
-	DatabaseAddress          string        `envconfig:"DATABASE_ADDRESS" json:"-"`
-	Neo4jPoolSize            int           `envconfig:"NEO4J_POOL_SIZE"`
-	FilterAPIURL             string        `envconfig:"FILTER_API_URL"`
-	FilterAPIAuthToken       string        `envconfig:"FILTER_API_AUTH_TOKEN" json:"-"`
-	AWSRegion                string        `envconfig:"AWS_REGION"`
-	S3BucketName             string        `envconfig:"S3_BUCKET_NAME"`
-	S3PrivateBucketName      string        `envconfig:"S3_PRIVATE_BUCKET_NAME"`
-	CSVExportedProducerTopic string        `envconfig:"CSV_EXPORTED_PRODUCER_TOPIC"`
-	DatasetAPIURL            string        `envconfig:"DATASET_API_URL"`
-	DatasetAPIAuthToken      string        `envconfig:"DATASET_API_AUTH_TOKEN" json:"-"`
-	ErrorProducerTopic       string        `envconfig:"ERROR_PRODUCER_TOPIC"`
-	GracefulShutdownTimeout  time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
-	HealthCheckInterval      time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
-	VaultToken               string        `envconfig:"VAULT_TOKEN"                json:"-"`
-	VaultAddress             string        `envconfig:"VAULT_ADDR"`
-	VaultPath                string        `envconfig:"VAULT_PATH"`
-	DownloadServiceURL       string        `envconfig:"DOWNLOAD_SERVICE_URL"`
-	ServiceAuthToken         string        `envconfig:"SERVICE_AUTH_TOKEN" json:"-"`
-	ZebedeeURL               string        `envconfig:"ZEBEDEE_URL"`
+	BindAddr                  string        `envconfig:"BIND_ADDR"`
+	KafkaAddr                 []string      `envconfig:"KAFKA_ADDR"`
+	FilterConsumerGroup       string        `envconfig:"FILTER_JOB_CONSUMER_GROUP"`
+	FilterConsumerTopic       string        `envconfig:"FILTER_JOB_CONSUMER_TOPIC"`
+	DatabaseAddress           string        `envconfig:"DATABASE_ADDRESS" json:"-"`
+	Neo4jPoolSize             int           `envconfig:"NEO4J_POOL_SIZE"`
+	FilterAPIURL              string        `envconfig:"FILTER_API_URL"`
+	FilterAPIAuthToken        string        `envconfig:"FILTER_API_AUTH_TOKEN" json:"-"`
+	AWSRegion                 string        `envconfig:"AWS_REGION"`
+	S3BucketName              string        `envconfig:"S3_BUCKET_NAME"`
+	S3PrivateBucketName       string        `envconfig:"S3_PRIVATE_BUCKET_NAME"`
+	CSVExportedProducerTopic  string        `envconfig:"CSV_EXPORTED_PRODUCER_TOPIC"`
+	DatasetAPIURL             string        `envconfig:"DATASET_API_URL"`
+	DatasetAPIAuthToken       string        `envconfig:"DATASET_API_AUTH_TOKEN" json:"-"`
+	ErrorProducerTopic        string        `envconfig:"ERROR_PRODUCER_TOPIC"`
+	GracefulShutdownTimeout   time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
+	HealthCheckInterval       time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
+	VaultToken                string        `envconfig:"VAULT_TOKEN"                json:"-"`
+	VaultAddress              string        `envconfig:"VAULT_ADDR"`
+	VaultPath                 string        `envconfig:"VAULT_PATH"`
+	DownloadServiceURL        string        `envconfig:"DOWNLOAD_SERVICE_URL"`
+	ServiceAuthToken          string        `envconfig:"SERVICE_AUTH_TOKEN" json:"-"`
+	ZebedeeURL                string        `envconfig:"ZEBEDEE_URL"`
+	FullDatasetFilePrefix     string        `envconfig:"FULL_DATASET_FILE_PREFIX"`
+	FilteredDatasetFilePrefix string        `envconfig:"FILTERED_DATASET_FILE_PREFIX"`
 }
 
 // Get the configuration values from the environment or provide the defaults.
 func Get() (*Config, error) {
 
 	cfg := &Config{
-		BindAddr:                 ":22500",
-		KafkaAddr:                []string{"localhost:9092"},
-		FilterConsumerTopic:      "filter-job-submitted",
-		FilterConsumerGroup:      "dp-dataset-exporter",
-		DatabaseAddress:          "bolt://localhost:7687",
-		Neo4jPoolSize:            5,
-		FilterAPIURL:             "http://localhost:22100",
-		FilterAPIAuthToken:       "FD0108EA-825D-411C-9B1D-41EF7727F465",
-		CSVExportedProducerTopic: "common-output-created",
-		S3BucketName:             "csv-exported",
-		S3PrivateBucketName:      "csv-exported",
-		AWSRegion:                "eu-west-1",
-		DatasetAPIURL:            "http://localhost:22000",
-		DatasetAPIAuthToken:      "FD0108EA-825D-411C-9B1D-41EF7727F465",
-		ErrorProducerTopic:       "filter-error",
-		GracefulShutdownTimeout:  time.Second * 10,
-		HealthCheckInterval:      time.Minute,
-		VaultPath:                "secret/shared/psk",
-		VaultAddress:             "http://localhost:8200",
-		VaultToken:               "",
-		DownloadServiceURL:       "http://localhost:23600",
-		ServiceAuthToken:         "0f49d57b-c551-4d33-af1e-a442801dd851",
-		ZebedeeURL:               "http://localhost:8082",
+		BindAddr:                  ":22500",
+		KafkaAddr:                 []string{"localhost:9092"},
+		FilterConsumerTopic:       "filter-job-submitted",
+		FilterConsumerGroup:       "dp-dataset-exporter",
+		DatabaseAddress:           "bolt://localhost:7687",
+		Neo4jPoolSize:             5,
+		FilterAPIURL:              "http://localhost:22100",
+		FilterAPIAuthToken:        "FD0108EA-825D-411C-9B1D-41EF7727F465",
+		CSVExportedProducerTopic:  "common-output-created",
+		S3BucketName:              "csv-exported",
+		S3PrivateBucketName:       "csv-exported",
+		AWSRegion:                 "eu-west-1",
+		DatasetAPIURL:             "http://localhost:22000",
+		DatasetAPIAuthToken:       "FD0108EA-825D-411C-9B1D-41EF7727F465",
+		ErrorProducerTopic:        "filter-error",
+		GracefulShutdownTimeout:   time.Second * 10,
+		HealthCheckInterval:       time.Minute,
+		VaultPath:                 "secret/shared/psk",
+		VaultAddress:              "http://localhost:8200",
+		VaultToken:                "",
+		DownloadServiceURL:        "http://localhost:23600",
+		ServiceAuthToken:          "0f49d57b-c551-4d33-af1e-a442801dd851",
+		ZebedeeURL:                "http://localhost:8082",
+		FullDatasetFilePrefix:     "full-datasets/",
+		FilteredDatasetFilePrefix: "filtered-datasets/",
 	}
 
 	err := envconfig.Process("", cfg)

--- a/file/store.go
+++ b/file/store.go
@@ -43,7 +43,12 @@ type Store struct {
 }
 
 // NewStore returns a new store instance for the given AWS region and S3 bucket name.
-func NewStore(region string, publicBucket, privateBucket, vaultPath string, vaultClient VaultClient) (*Store, error) {
+func NewStore(
+	region,
+	publicBucket,
+	privateBucket,
+	vaultPath string,
+	vaultClient VaultClient) (*Store, error) {
 
 	config := aws.NewConfig().WithRegion(region)
 
@@ -63,9 +68,7 @@ func NewStore(region string, publicBucket, privateBucket, vaultPath string, vaul
 }
 
 // PutFile stores the contents of the given reader to a csv file of given the supplied name.
-func (store *Store) PutFile(reader io.Reader, fileID string, isPublished bool) (url string, err error) {
-
-	filename := fileID + ".csv"
+func (store *Store) PutFile(reader io.Reader, filename string, isPublished bool) (url string, err error) {
 
 	var location string
 	if isPublished {

--- a/filter/store.go
+++ b/filter/store.go
@@ -30,7 +30,7 @@ type FilterOuput struct {
 	InstanceID string     `json:"instance_id"`
 	State      string     `json:"state,omitempty"`
 	Downloads  *Downloads `json:"downloads,omitempty"`
-	Events     []*Event    `json:"events,omitempty"`
+	Events     []*Event   `json:"events,omitempty"`
 	Published  bool       `json:"published,omitempty"`
 }
 


### PR DESCRIPTION
### What

* Apply configured prefixes for s3 filenames. This allows files uploaded to s3 to be uploaded within a folder in the bucket
* Add missing handler test for full dataset downloads

### How to review

Review code / test

### Who can review

Anyone