### PR TITLE
Allow api host to be configured

### DIFF
--- a/cmd/dp-dataset-exporter/main.go
+++ b/cmd/dp-dataset-exporter/main.go
@@ -91,6 +91,7 @@ func main() {
 		eventProducer,
 		datasetAPICli,
 		cfg.DownloadServiceURL,
+		cfg.APIDomainURL,
 		cfg.FullDatasetFilePrefix,
 		cfg.FilteredDatasetFilePrefix,
 	)

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	VaultAddress                string        `envconfig:"VAULT_ADDR"`
 	VaultPath                   string        `envconfig:"VAULT_PATH"`
 	DownloadServiceURL          string        `envconfig:"DOWNLOAD_SERVICE_URL"`
+	APIDomainURL                string        `envconfig:"API_DOMAIN_URL"`
 	ServiceAuthToken            string        `envconfig:"SERVICE_AUTH_TOKEN"            json:"-"`
 	StartupTimeout              time.Duration `envconfig:"STARTUP_TIMEOUT"`
 	ZebedeeURL                  string        `envconfig:"ZEBEDEE_URL"`
@@ -60,6 +61,7 @@ func Get() (*Config, error) {
 		VaultAddress:                "http://localhost:8200",
 		VaultToken:                  "",
 		DownloadServiceURL:          "http://localhost:23600",
+		APIDomainURL:                "http://localhost:23200",
 		ServiceAuthToken:            "0f49d57b-c551-4d33-af1e-a442801dd851",
 		StartupTimeout:              time.Second * 125,
 		ZebedeeURL:                  "http://localhost:8082",

--- a/csvw/csvw_test.go
+++ b/csvw/csvw_test.go
@@ -259,7 +259,7 @@ func TestGenerate(t *testing.T) {
 			data, err := Generate(m, header, fileURL, fileURL, apiURL)
 
 			Convey("Then results should be returned with no errors", func() {
-				So(data, ShouldHaveLength, 518)
+				So(data, ShouldHaveLength, 367)
 				So(err, ShouldBeNil)
 			})
 		})

--- a/csvw/csvw_test.go
+++ b/csvw/csvw_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 var fileURL = "ons/file.csv"
+var apiURL = "api.example.com"
 
 func TestNew(t *testing.T) {
 	Convey("Given a complete metadata struct", t, func() {
@@ -255,10 +256,10 @@ func TestGenerate(t *testing.T) {
 		}
 
 		Convey("When the Generate csvw function is called", func() {
-			data, err := Generate(m, header, fileURL, fileURL)
+			data, err := Generate(m, header, fileURL, fileURL, apiURL)
 
 			Convey("Then results should be returned with no errors", func() {
-				So(data, ShouldHaveLength, 503)
+				So(data, ShouldHaveLength, 518)
 				So(err, ShouldBeNil)
 			})
 		})
@@ -273,7 +274,7 @@ func TestGenerate(t *testing.T) {
 		}
 
 		Convey("When the Generate csvw function is called", func() {
-			data, err := Generate(m, header, fileURL, fileURL)
+			data, err := Generate(m, header, fileURL, fileURL, apiURL)
 
 			Convey("Then results should be returned with no errors", func() {
 				So(data, ShouldHaveLength, 0)

--- a/event/handler.go
+++ b/event/handler.go
@@ -38,6 +38,7 @@ type ExportHandler struct {
 	eventProducer             Producer
 	datasetAPICli             DatasetAPI
 	downloadServiceURL        string
+	apiDomainURL              string
 	fullDatasetFilePrefix     string
 	filteredDatasetFilePrefix string
 }
@@ -59,6 +60,7 @@ func NewExportHandler(
 	eventProducer Producer,
 	datasetAPI DatasetAPI,
 	downloadServiceURL,
+	apiDomainURL,
 	fullDatasetFilePrefix,
 	filteredDatasetFilePrefix string,
 ) *ExportHandler {
@@ -70,6 +72,7 @@ func NewExportHandler(
 		eventProducer:             eventProducer,
 		datasetAPICli:             datasetAPI,
 		downloadServiceURL:        downloadServiceURL,
+		apiDomainURL:              apiDomainURL,
 		fullDatasetFilePrefix:     fullDatasetFilePrefix,
 		filteredDatasetFilePrefix: filteredDatasetFilePrefix,
 	}
@@ -341,7 +344,7 @@ func (handler *ExportHandler) generateMetadata(event *FilterSubmitted, s3path, h
 
 	aboutURL := handler.datasetAPICli.GetMetadataURL(event.DatasetID, event.Edition, event.Version)
 
-	csvwFile, err := csvw.Generate(&m, header, downloadURL, aboutURL)
+	csvwFile, err := csvw.Generate(&m, header, downloadURL, aboutURL, handler.apiDomainURL)
 	if err != nil {
 		return nil, err
 	}

--- a/event/handler_test.go
+++ b/event/handler_test.go
@@ -23,6 +23,7 @@ const (
 	ServiceToken    = "gravy"
 
 	downloadServiceURL        = "http://download-service"
+	apiDomainURL              = "http://api-example"
 	fullDatasetFilePrefix     = "full-dataset"
 	filteredDatasetFilePrefix = "filtered-dataset"
 )
@@ -103,7 +104,7 @@ func TestExportHandler_Handle_FilterStoreGetError(t *testing.T) {
 			},
 		}
 
-		handler := event.NewExportHandler(mockFilterStore, nil, nil, nil, datasetAPIMock, downloadServiceURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
+		handler := event.NewExportHandler(mockFilterStore, nil, nil, nil, datasetAPIMock, downloadServiceURL, apiDomainURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
 
 		Convey("When handle is called", func() {
 
@@ -145,7 +146,7 @@ func TestExportHandler_Handle_ObservationStoreError(t *testing.T) {
 			},
 		}
 
-		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, nil, nil, datasetAPIMock, downloadServiceURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
+		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, nil, nil, datasetAPIMock, downloadServiceURL, apiDomainURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
 
 		Convey("When handle is called", func() {
 
@@ -198,7 +199,7 @@ func TestExportHandler_Handle_FileStoreError(t *testing.T) {
 			},
 		}
 
-		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, nil, datasetAPIMock, downloadServiceURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
+		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, nil, datasetAPIMock, downloadServiceURL, apiDomainURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
 
 		Convey("When handle is called", func() {
 
@@ -255,7 +256,7 @@ func TestExportHandler_Handle_Empty_Results(t *testing.T) {
 			},
 		}
 
-		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, nil, datasetAPIMock, downloadServiceURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
+		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, nil, datasetAPIMock, downloadServiceURL, apiDomainURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
 
 		Convey("When handle is called", func() {
 			ctx := context.Background()
@@ -313,7 +314,7 @@ func TestExportHandler_Handle_Instance_Not_Found(t *testing.T) {
 			},
 		}
 
-		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, nil, datasetAPIMock, downloadServiceURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
+		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, nil, datasetAPIMock, downloadServiceURL, apiDomainURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
 
 		Convey("When handle is called", func() {
 			ctx := context.Background()
@@ -370,7 +371,7 @@ func TestExportHandler_Handle_FilterStorePutError(t *testing.T) {
 			},
 		}
 
-		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, nil, datasetAPIMock, downloadServiceURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
+		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, nil, datasetAPIMock, downloadServiceURL, apiDomainURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
 
 		Convey("When handle is called", func() {
 			ctx := context.Background()
@@ -436,7 +437,7 @@ func TestExportHandler_Handle_EventProducerError(t *testing.T) {
 			},
 		}
 
-		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, mockedEventProducer, datasetAPIMock, downloadServiceURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
+		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, mockedEventProducer, datasetAPIMock, downloadServiceURL, apiDomainURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
 
 		Convey("When handle is called", func() {
 			ctx := context.Background()
@@ -500,7 +501,7 @@ func TestExportHandler_Handle_Filter(t *testing.T) {
 			},
 		}
 
-		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, mockedEventProducer, datasetAPIMock, downloadServiceURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
+		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, mockedEventProducer, datasetAPIMock, downloadServiceURL, apiDomainURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
 
 		Convey("When handle is called", func() {
 			ctx := context.Background()
@@ -611,7 +612,7 @@ func TestExportHandler_Handle_FullFileDownload(t *testing.T) {
 			},
 		}
 
-		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, mockedEventProducer, datasetAPIMock, downloadServiceURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
+		handler := event.NewExportHandler(mockFilterStore, mockObservationStore, mockedFileStore, mockedEventProducer, datasetAPIMock, downloadServiceURL, apiDomainURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
 
 		Convey("When handle is called", func() {
 			ctx := context.Background()
@@ -714,7 +715,7 @@ func TestExportHandler_HandlePrePublish(t *testing.T) {
 			return metadata, nil
 		}
 
-		handler := event.NewExportHandler(filterStoreMock, observationStoreMock, fileStockMock, producerMock, datasetApiMock, downloadServiceURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
+		handler := event.NewExportHandler(filterStoreMock, observationStoreMock, fileStockMock, producerMock, datasetApiMock, downloadServiceURL, apiDomainURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
 
 		Convey("when handle is called", func() {
 			ctx := context.Background()
@@ -759,7 +760,7 @@ func TestExportHandler_HandlePrePublish(t *testing.T) {
 			return "", mockErr
 		}
 
-		handler := event.NewExportHandler(filterStoreMock, observationStoreMock, fileStockMock, producerMock, datasetApiMock, downloadServiceURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
+		handler := event.NewExportHandler(filterStoreMock, observationStoreMock, fileStockMock, producerMock, datasetApiMock, downloadServiceURL, apiDomainURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
 
 		Convey("when handle is called", func() {
 			ctx := context.Background()
@@ -824,7 +825,7 @@ func TestExportHandler_HandlePrePublish(t *testing.T) {
 			return nil
 		}
 
-		handler := event.NewExportHandler(filterStoreMock, observationStoreMock, fileStockMock, producerMock, datasetApiMock, downloadServiceURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
+		handler := event.NewExportHandler(filterStoreMock, observationStoreMock, fileStockMock, producerMock, datasetApiMock, downloadServiceURL, apiDomainURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
 
 		Convey("when handle is called", func() {
 			ctx := context.Background()
@@ -876,7 +877,7 @@ func TestExportHandler_HandlePrePublish(t *testing.T) {
 			return csvRowReaderMock, nil
 		}
 
-		handler := event.NewExportHandler(filterStoreMock, observationStoreMock, fileStockMock, producerMock, datasetApiMock, downloadServiceURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
+		handler := event.NewExportHandler(filterStoreMock, observationStoreMock, fileStockMock, producerMock, datasetApiMock, downloadServiceURL, apiDomainURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
 
 		Convey("when handle is called", func() {
 			ctx := context.Background()
@@ -940,7 +941,7 @@ func TestExportHandler_HandlePrePublish(t *testing.T) {
 			return nil
 		}
 
-		handler := event.NewExportHandler(filterStoreMock, observationStoreMock, fileStockMock, producerMock, datasetApiMock, downloadServiceURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
+		handler := event.NewExportHandler(filterStoreMock, observationStoreMock, fileStockMock, producerMock, datasetApiMock, downloadServiceURL, apiDomainURL, fullDatasetFilePrefix, filteredDatasetFilePrefix)
 
 		Convey("when handle is called", func() {
 			ctx := context.Background()


### PR DESCRIPTION
### What

-Add config for api host domain (this will need to include the '/v1')
-Update valueURL creation to replace 'localhost' with the public api url for that env
-Remove `@id` fields in columns, as they may have been syntactically wrong and were possibly pointing to the wrong columns anyway.

### How to review

Check a CSVW is still generated, the valueURLs can be configured and the `@id` fields are gone
https://github.com/ONSdigital/dp-ci/pull/439

### Who can review

Anyone