### PR TITLE
Add total row count to csv exported event

### DIFF
--- a/event/csv_exported.go
+++ b/event/csv_exported.go
@@ -9,4 +9,5 @@ type CSVExported struct {
 	Edition    string `avro:"edition"`
 	Version    string `avro:"version"`
 	Filename   string `avro:"filename"`
+	RowCount   int32  `avro:"row_count"`
 }

--- a/event/producer_test.go
+++ b/event/producer_test.go
@@ -49,6 +49,7 @@ func TestAvroProducer_CSVExported(t *testing.T) {
 				Version:    "",
 				FileURL:    "",
 				Filename:   "",
+				RowCount:   0,
 			}
 			err := eventProducer.CSVExported(event)
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -31,7 +31,8 @@ var csvExportedEvent = `{
     {"name": "dataset_id", "type": "string", "default": ""},
     {"name": "edition", "type": "string", "default": ""},
     {"name": "version", "type": "string", "default": ""},
-    {"name": "filename", "type": "string", "default": ""}
+    {"name": "filename", "type": "string", "default": ""},
+    {"name": "row_count", "type": "int", "default": 0}
   ]
 }`
 

--- a/vendor/github.com/ONSdigital/dp-filter/observation/reader.go
+++ b/vendor/github.com/ONSdigital/dp-filter/observation/reader.go
@@ -11,6 +11,7 @@ type Reader struct {
 	buffer         []byte // buffer a portion of the current line
 	eof            bool   // are we at the end of the csv rows?
 	totalBytesRead int64  // how many bytes in total have been read?
+	obsCount       int32
 }
 
 // NewReader returns a new io.Reader for the given csvRowReader.
@@ -33,6 +34,7 @@ func (reader *Reader) Read(p []byte) (n int, err error) {
 		}
 
 		reader.buffer = []byte(csvRow)
+		reader.obsCount++
 	}
 
 	// copy into the given byte array.
@@ -61,4 +63,9 @@ func (reader *Reader) Close() (err error) {
 // TotalBytesRead returns the total number of bytes read by this reader.
 func (reader *Reader) TotalBytesRead() int64 {
 	return reader.totalBytesRead
+}
+
+// ObservationsCount returns the total number of bytes read by this reader.
+func (reader *Reader) ObservationsCount() int32 {
+	return reader.obsCount
 }

--- a/vendor/github.com/ONSdigital/dp-filter/observation/store.go
+++ b/vendor/github.com/ONSdigital/dp-filter/observation/store.go
@@ -78,10 +78,11 @@ func createObservationQuery(filter *Filter) string {
 	with := " WITH "
 	match := " MATCH "
 
-	for index, dimension := range filter.DimensionFilters {
+	count := 0
+	for _, dimension := range filter.DimensionFilters {
 		// If the dimension options is empty then don't bother specifying in the query as this will exclude all matches.
 		if len(dimension.Options) > 0 {
-			if index != 0 {
+			if count > 0 {
 				matchDimensions += ", "
 				where += " AND "
 				with += ", "
@@ -93,6 +94,7 @@ func createObservationQuery(filter *Filter) string {
 			where += fmt.Sprintf("%s.value IN [%s]", dimension.Name, optionList)
 			with += dimension.Name
 			match += fmt.Sprintf("(o:`_%s_observation`)-[:isValueOf]->(%s)", filter.InstanceID, dimension.Name)
+			count++
 		}
 	}
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -5,8 +5,8 @@
 		{
 			"checksumSHA1": "jxN1glVYv3lRwGmSNAy2a/HhxtM=",
 			"path": "github.com/ONSdigital/dp-filter/observation",
-			"revision": "f56797ab6de5f156eec979f304eee91872e00234",
-			"revisionTime": "2018-06-06T07:52:38Z"
+			"revision": "57de43d99daf6bd6cc44de9a5ca8ddebe6e524db",
+			"revisionTime": "2018-09-13T13:44:53Z"
 		},
 		{
 			"checksumSHA1": "Y2c7VzzVtF7hubSrnyYZHsvFVDs=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,7 +3,7 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "qhFKyZRRovlrhBNLfxRZPG2IlWE=",
+			"checksumSHA1": "jxN1glVYv3lRwGmSNAy2a/HhxtM=",
 			"path": "github.com/ONSdigital/dp-filter/observation",
 			"revision": "f56797ab6de5f156eec979f304eee91872e00234",
 			"revisionTime": "2018-06-06T07:52:38Z"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "jxN1glVYv3lRwGmSNAy2a/HhxtM=",
+			"checksumSHA1": "MVaIRfOginBKt/GpnmwHJAz0IgE=",
 			"path": "github.com/ONSdigital/dp-filter/observation",
-			"revision": "57de43d99daf6bd6cc44de9a5ca8ddebe6e524db",
-			"revisionTime": "2018-09-13T13:44:53Z"
+			"revision": "89cac8d67da4cee0cba8c1da92262b4e38c566c9",
+			"revisionTime": "2018-09-19T14:55:59Z"
 		},
 		{
 			"checksumSHA1": "Y2c7VzzVtF7hubSrnyYZHsvFVDs=",


### PR DESCRIPTION
### What

add total row count to the exported event for other services to determine if they have capacity to process a message of this size

### How to review

goes with:
https://github.com/ONSdigital/dp-dataset-exporter-xlsx/pull/76
https://github.com/ONSdigital/dp-filter-api/pull/112

check row count is included in produced event

### Who can review

anyone