### PR TITLE
Update graceful shutdown

### DIFF
--- a/initialise/initialise.go
+++ b/initialise/initialise.go
@@ -1,0 +1,98 @@
+package initialise
+
+import (
+	"context"
+
+	"github.com/ONSdigital/dp-dataset-exporter/config"
+	"github.com/ONSdigital/dp-dataset-exporter/file"
+	"github.com/ONSdigital/dp-graph/graph"
+	"github.com/ONSdigital/go-ns/kafka"
+	"github.com/ONSdigital/go-ns/vault"
+)
+
+// ExternalServiceList represents a list of services
+type ExternalServiceList struct {
+	Consumer            bool
+	CSVExportedProducer bool
+	ErrorProducer       bool
+	FileStore           bool
+	ObservationStore    bool
+	HealthTicker        bool
+	Vault               bool
+}
+
+const (
+	// CSVExportedProducer represents a name for
+	// the producer that writes to a csv exported topic
+	CSVExportedProducer = "csv-exported-producer"
+	// ErrorProducer represents a name for
+	// the producer that writes to an error topic
+	ErrorProducer = "error-producer"
+)
+
+// GetConsumer returns an initialised kafka consumer
+func (e *ExternalServiceList) GetConsumer(kafkaBrokers []string, cfg *config.Config) (kafkaConsumer *kafka.ConsumerGroup, err error) {
+	kafkaConsumer, err = kafka.NewSyncConsumer(
+		kafkaBrokers,
+		cfg.FilterConsumerTopic,
+		cfg.FilterConsumerGroup,
+		kafka.OffsetNewest,
+	)
+
+	if err == nil {
+		e.Consumer = true
+	}
+
+	return
+}
+
+// GetFileStore returns an initialised connection to file store
+func (e *ExternalServiceList) GetFileStore(cfg *config.Config, vaultClient *vault.VaultClient) (fileStore *file.Store, err error) {
+	fileStore, err = file.NewStore(
+		cfg.AWSRegion,
+		cfg.S3BucketName,
+		cfg.S3PrivateBucketName,
+		cfg.VaultPath,
+		vaultClient,
+	)
+	if err == nil {
+		e.FileStore = true
+	}
+
+	return
+}
+
+// GetObservationStore returns an initialised connection to observation store (graph database)
+func (e *ExternalServiceList) GetObservationStore() (observationStore *graph.DB, err error) {
+	observationStore, err = graph.New(context.Background(), graph.Subsets{Observation: true})
+	if err == nil {
+		e.ObservationStore = true
+	}
+
+	return
+}
+
+// GetProducer returns a kafka producer
+func (e *ExternalServiceList) GetProducer(kafkaBrokers []string, topic, name string) (kafkaProducer kafka.Producer, err error) {
+	kafkaProducer, err = kafka.NewProducer(kafkaBrokers, topic, 0)
+	if err == nil {
+		switch {
+		case name == CSVExportedProducer:
+			e.CSVExportedProducer = true
+		case name == ErrorProducer:
+			e.ErrorProducer = true
+		}
+	}
+
+	return
+}
+
+// GetVault returns a vault client
+func (e *ExternalServiceList) GetVault(cfg *config.Config, retries int) (client *vault.VaultClient, err error) {
+	client, err = vault.CreateVaultClient(cfg.VaultToken, cfg.VaultAddress, retries)
+	if err == nil {
+		e.Vault = true
+	}
+
+	return
+}


### PR DESCRIPTION
### What

Do not force application to shutdown on startup due to services not being unavailable (including connecting to kafka).

Currently there is no healthcheck for kafka and hence there is some extra code to handle when the app fails to connect to kafka on startup, this will allow the service to stay running but will not attempt to consume messages off kafka topic. ONS internal library for kafka has no health (check) function and hence this application will return health status 200 even if it cannot connect to kafka.

### How to review

Check service runs even if kafka is not running - application will now continually run but kafka library does not contain a health (check)function and so the application health check will return a false positive in a status `OK (200)`  

### Who can review

Anyone
