### PR TITLE
Re-implement removed error logs

### DIFF
--- a/cmd/dp-dataset-exporter/main.go
+++ b/cmd/dp-dataset-exporter/main.go
@@ -129,6 +129,19 @@ func main() {
 		}
 	}()
 
+	go func() {
+		select {
+		case err := <-kafkaConsumer.Errors():
+			log.ErrorC("kafka consumer", err, nil)
+		case err := <-kafkaProducer.Errors():
+			log.ErrorC("kafka result producer", err, nil)
+		case err := <-kafkaErrorProducer.Errors():
+			log.ErrorC("kafka error producer", err, nil)
+		case err := <-errorChannel:
+			log.ErrorC("error channel", err, nil)
+		}
+	}()
+
 	// block until a fatal error occurs
 	select {
 	case <-signals:


### PR DESCRIPTION
### What

Re-implement error logs when connections are lost during the running of application.

This was previously removed when work to prevent calls to gracefully shutdown on these errors.

### How to review

Check errors are logged when kafka is terminated.

### Who can review

Anyone
