### PR TITLE
Add DownloadServiceInternalURL to enable nomad access

### DIFF
--- a/cmd/dp-dataset-exporter/main.go
+++ b/cmd/dp-dataset-exporter/main.go
@@ -123,7 +123,7 @@ func main() {
 		vaultClient,
 		datasetAPICli,
 		filterAPIClient,
-		health.NewClient("DownloadService", cfg.DownloadServiceURL),
+		health.NewClient("DownloadService", cfg.DownloadServiceInternalURL),
 		health.NewClient("Zebedee", cfg.ZebedeeURL),
 		fileStore.Uploader, fileStore.CryptoUploader)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	VaultAddress                string        `envconfig:"VAULT_ADDR"`
 	VaultPath                   string        `envconfig:"VAULT_PATH"`
 	DownloadServiceURL          string        `envconfig:"DOWNLOAD_SERVICE_URL"`
+	DownloadServiceInternalURL  string        `envconfig:"DOWNLOAD_SERVICE_INTERNAL_URL"`
 	APIDomainURL                string        `envconfig:"API_DOMAIN_URL"`
 	ServiceAuthToken            string        `envconfig:"SERVICE_AUTH_TOKEN"            json:"-"`
 	StartupTimeout              time.Duration `envconfig:"STARTUP_TIMEOUT"`
@@ -59,6 +60,7 @@ func Get() (*Config, error) {
 		VaultAddress:                "http://localhost:8200",
 		VaultToken:                  "",
 		DownloadServiceURL:          "http://localhost:23600",
+		DownloadServiceInternalURL:  "http://localhost:23600",
 		APIDomainURL:                "http://localhost:23200",
 		ServiceAuthToken:            "0f49d57b-c551-4d33-af1e-a442801dd851",
 		StartupTimeout:              time.Second * 125,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -39,6 +39,7 @@ func TestSpec(t *testing.T) {
 				So(cfg.VaultPath, ShouldEqual, "secret/shared/psk")
 				So(cfg.VaultToken, ShouldEqual, "")
 				So(cfg.DownloadServiceURL, ShouldEqual, "http://localhost:23600")
+				So(cfg.DownloadServiceInternalURL, ShouldEqual, "http://localhost:23600")
 				So(cfg.ServiceAuthToken, ShouldEqual, "0f49d57b-c551-4d33-af1e-a442801dd851")
 				So(cfg.StartupTimeout, ShouldEqual, 125*time.Second)
 			})


### PR DESCRIPTION
### What

- Added DownloadServiceInternalURL config, so that nomad has access to the `/health` endpoint

### How to review

- Make sure changes make sense. After this change, and adding the required env var in secrets, this service should be deployed correctly in develop.

### Who can review

Anyone