### PR TITLE
Upgrade dp-graph to v2.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.9.0
-	github.com/ONSdigital/dp-graph/v2 v2.0.12
+	github.com/ONSdigital/dp-graph/v2 v2.1.1
 	github.com/ONSdigital/dp-healthcheck v1.0.3
 	github.com/ONSdigital/dp-kafka v1.1.5
 	github.com/ONSdigital/dp-s3 v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/ONSdigital/dp-api-clients-go v1.1.0/go.mod h1:9lqor0I7caCnRWr04gU/r7x
 github.com/ONSdigital/dp-api-clients-go v1.9.0 h1:ru8jBPAxXfibYOF41/tU/ZtOt4tUVEszpMraHAbmvxA=
 github.com/ONSdigital/dp-api-clients-go v1.9.0/go.mod h1:SM0b/NXDWndJ9EulmAGdfDY4DxPxK+pNsP8eZlIWiqM=
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
-github.com/ONSdigital/dp-graph/v2 v2.0.12 h1:5h+GT2aorgxQIXJY3pzuvDOTOk6RSaUbP8wG1xSbBJg=
-github.com/ONSdigital/dp-graph/v2 v2.0.12/go.mod h1:6C59rOY0qBKblczkQrJZZKa8ZLR3yKkyunSCeIUavtU=
+github.com/ONSdigital/dp-graph/v2 v2.1.1 h1:abbPKI0S+o+SKJpDdDHlFevzfxWIN3E5s4GJn7R/Fo4=
+github.com/ONSdigital/dp-graph/v2 v2.1.1/go.mod h1:6C59rOY0qBKblczkQrJZZKa8ZLR3yKkyunSCeIUavtU=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.0 h1:bySQU8kQRs4n3WbgH8QtVwCJLqG9ri722saATjvNNfc=
 github.com/ONSdigital/dp-healthcheck v1.0.0/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=


### PR DESCRIPTION
### What
Upgrade dp-graph to v2.1.1
 - contains fix for Neptune observation query, to ensure the header gets correctly injected only as the first row.

### How to review
Sanity check

### Who can review
If you're reading this, I am hoping that you can 😉 