### PR TITLE
Ensure messages are committed on error

### DIFF
--- a/event/consumer_test.go
+++ b/event/consumer_test.go
@@ -93,6 +93,10 @@ func TestConsume(t *testing.T) {
 			Convey("The message is committed", func() {
 				So(len(message.CommitCalls()), ShouldEqual, 1)
 			})
+
+			Convey("and the Kafka consumer is released", func() {
+				So(len(mockConsumer.CommitAndReleaseCalls()), ShouldEqual, 1)
+			})
 		})
 	})
 }
@@ -134,8 +138,12 @@ func TestConsume_HandlerError(t *testing.T) {
 				So(mockErrorHandler.HandleCalls()[0].FilterID, ShouldEqual, expectedEvent.FilterID)
 			})
 
-			Convey("and the message is not committed - to be retried", func() {
-				So(len(message.CommitCalls()), ShouldEqual, 0)
+			Convey("and the message is committed - we assume any retry logic has occurred within the consumer", func() {
+				So(len(message.CommitCalls()), ShouldEqual, 1)
+			})
+
+			Convey("and the Kafka consumer is released", func() {
+				So(len(mockConsumer.CommitAndReleaseCalls()), ShouldEqual, 1)
 			})
 		})
 	})


### PR DESCRIPTION
### What
Ensure messages are committed on error
- This change ensures that messages are committed and the consumer is
released if an error occurs. Before the change, any error that bubbles up to the consumer will cause
it to be blocked and no longer consume messages.
- Any retry logic should be completed within the handler. When a
message bubbles up to the top level of the consumer, it is not
considered to be retry-able.
- refactor log message on error to be an error log

### How to review
Review and check tests pass

### Who can review
Anyone
