### PR TITLE
Added log on consumer stopped listen

### DIFF
--- a/event/consumer.go
+++ b/event/consumer.go
@@ -45,6 +45,7 @@ func NewConsumer() *Consumer {
 func (consumer *Consumer) Consume(messageConsumer MessageConsumer, handler Handler, errorHandler errors.Handler) {
 
 	go func() {
+		defer log.Event(nil, "===== Consumer stopped listening")
 		defer close(consumer.closed)
 
 		for {


### PR DESCRIPTION
### What

- Added extra debug log when consumer goroutine finishes.
This log is not supposed to be released to production and will be rolled back once the Kafka issue is fixed.

### How to review

-Make sure log makes sense

### Who can review

Anyone