### PR TITLE
Update filename generation for csv files

### DIFF
--- a/event/handler_test.go
+++ b/event/handler_test.go
@@ -40,7 +40,10 @@ var cfg = &config.Config{
 }
 
 var filterSubmittedEvent = &event.FilterSubmitted{
-	FilterID: filterOutputId,
+	FilterID:  filterOutputId,
+	DatasetID: "12345",
+	Edition:   "2018",
+	Version:   "1",
 }
 
 var fullFileDownloadSubmittedEvent = &event.FilterSubmitted{


### PR DESCRIPTION
### What

Full dataset downloads and filtered downloads will have a new location and filename when stored in aws.

This is to make sure the filenames are human readable.

### How to review

- Check code changes make sense
- Unit tests pass
- Generate a new filter on cmd dataset and successfully download csv and csvw (metadata file)
- Login as a florence user and create a new instance of a dataset, publish this dataset and check you can download the new version (full dataset) csv and csvw via the website

The new filename should be like so:

- Full dataset - `{dataset-id}-{edition}-v{version}.csv`
- Filtered dataset file - `{dataset-id}-{edition}-v{version}-filtered-{ISO-Date}.csv`

Depends on https://github.com/ONSdigital/dp-filter-api/pull/161

### Who can review

Anyone
