### PR TITLE
Allowed concurrent workers in consumer, configurable by KAFKA_CONSUME…

### DIFF
--- a/cmd/dp-dataset-exporter/main.go
+++ b/cmd/dp-dataset-exporter/main.go
@@ -110,7 +110,7 @@ func main() {
 	)
 
 	// eventConsumer will Consume when the service is healthy - see goroutine below
-	eventConsumer := event.NewConsumer()
+	eventConsumer := event.NewConsumer(cfg.KafkaConsumerWorkers)
 
 	// Create healthcheck object with versionInfo
 	hc, err := serviceList.GetHealthCheck(cfg, BuildTime, GitCommit, Version)

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	BindAddr                   string        `envconfig:"BIND_ADDR"`
 	KafkaAddr                  []string      `envconfig:"KAFKA_ADDR"`
 	KafkaVersion               string        `envconfig:"KAFKA_VERSION"`
+	KafkaConsumerWorkers       int           `envconfig:"KAFKA_CONSUMER_WORKERS"`
 	FilterConsumerGroup        string        `envconfig:"FILTER_JOB_CONSUMER_GROUP"`
 	FilterConsumerTopic        string        `envconfig:"FILTER_JOB_CONSUMER_TOPIC"`
 	FilterAPIURL               string        `envconfig:"FILTER_API_URL"`
@@ -44,6 +45,7 @@ func Get() (*Config, error) {
 		BindAddr:                   ":22500",
 		KafkaAddr:                  []string{"localhost:9092"},
 		KafkaVersion:               "1.0.2",
+		KafkaConsumerWorkers:       1,
 		FilterConsumerTopic:        "filter-job-submitted",
 		FilterConsumerGroup:        "dp-dataset-exporter",
 		FilterAPIURL:               "http://localhost:22100",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,6 +24,7 @@ func TestSpec(t *testing.T) {
 				So(cfg.BindAddr, ShouldEqual, ":22500")
 				So(cfg.KafkaAddr, ShouldResemble, []string{"localhost:9092"})
 				So(cfg.KafkaVersion, ShouldResemble, "1.0.2")
+				So(cfg.KafkaConsumerWorkers, ShouldEqual, 1)
 				So(cfg.FilterConsumerTopic, ShouldEqual, "filter-job-submitted")
 				So(cfg.FilterConsumerGroup, ShouldEqual, "dp-dataset-exporter")
 				So(cfg.FilterAPIURL, ShouldEqual, "http://localhost:22100")

--- a/event/consumer_test.go
+++ b/event/consumer_test.go
@@ -43,7 +43,7 @@ func TestConsume_UnmarshallError(t *testing.T) {
 		message := kafkatest.NewMessage(marshal(*expectedEvent), 1)
 		mockConsumer.Channels().Upstream <- message
 
-		consumer := event.NewConsumer()
+		consumer := event.NewConsumer(cfg.KafkaConsumerWorkers)
 
 		Convey("When consume messages is called", func() {
 			consumer.Consume(mockConsumer, mockEventHandler, nil)
@@ -76,7 +76,7 @@ func TestConsume(t *testing.T) {
 
 		mockConsumer.Channels().Upstream <- message
 
-		consumer := event.NewConsumer()
+		consumer := event.NewConsumer(1)
 
 		Convey("When consume is called", func() {
 			consumer.Consume(mockConsumer, mockEventHandler, nil)
@@ -121,7 +121,7 @@ func TestConsume_HandlerError(t *testing.T) {
 		message := kafkatest.NewMessage(marshal(*expectedEvent), 1)
 		mockConsumer.Channels().Upstream <- message
 
-		consumer := event.NewConsumer()
+		consumer := event.NewConsumer(1)
 
 		Convey("When consume is called", func() {
 			consumer.Consume(mockConsumer, mockEventHandler, mockErrorHandler)
@@ -156,7 +156,7 @@ func TestClose(t *testing.T) {
 
 		mockConsumer.Channels().Upstream <- message
 
-		consumer := event.NewConsumer()
+		consumer := event.NewConsumer(1)
 		consumer.Consume(mockConsumer, mockEventHandler, nil)
 		Convey("When close is called", func() {
 

--- a/initialise/initialise.go
+++ b/initialise/initialise.go
@@ -47,7 +47,7 @@ func (e *ExternalServiceList) GetConsumer(ctx context.Context, cfg *config.Confi
 		cfg.KafkaAddr,
 		cfg.FilterConsumerTopic,
 		cfg.FilterConsumerGroup,
-		kafka.CreateConsumerGroupChannels(1),
+		kafka.CreateConsumerGroupChannels(cfg.KafkaConsumerWorkers),
 		&kafka.ConsumerGroupConfig{KafkaVersion: &cfg.KafkaVersion},
 	)
 	if err != nil {


### PR DESCRIPTION
### What

As part of the Kafka Spike (https://trello.com/c/h9afwr6S/4887-spike-performance-test-dp-kafka-consuming-in-parallel-3d), we think that it would be a good idea to add an extra degree of freedom to control concurrency for services using the new dp-kafka library.

- Allowed multiple workers to consume messages concurrently (configurable)
- Add config value KAFKA_CONSUMER_WORKERS to change the number of workers that can consume messages concurrently. Default is 1 (same behaviour as now).

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

I locally tested that the messages are consumed concurrently with a dockerised Kafka cluster with 3 nodes, creating a topic with 60 partitions and 3 replicas.

### Who can review

Anyone