### PR TITLE
Updated to dp-kafka v2.1.0, which reintroduced CommitAndRelease (msg lvl)

### DIFF
--- a/event/consumer.go
+++ b/event/consumer.go
@@ -68,8 +68,8 @@ func (consumer *Consumer) Consume(messageConsumer MessageConsumer, handler Handl
 					log.Event(ctx, "event processed - committing message", log.INFO, logData)
 				}
 
-				message.Commit()
-				log.Event(ctx, "message committed", log.INFO, logData)
+				message.CommitAndRelease()
+				log.Event(ctx, "message committed and released", log.INFO, logData)
 
 			case event, ok := <-consumer.closing:
 				if !ok {

--- a/event/consumer_test.go
+++ b/event/consumer_test.go
@@ -90,7 +90,9 @@ func TestConsume(t *testing.T) {
 			})
 
 			Convey("The message is committed", func() {
-				So(len(message.CommitCalls()), ShouldEqual, 1)
+				So(message.IsMarked(), ShouldBeTrue)
+				So(message.IsCommitted(), ShouldBeTrue)
+				So(len(message.CommitAndReleaseCalls()), ShouldEqual, 1)
 			})
 		})
 	})
@@ -134,7 +136,9 @@ func TestConsume_HandlerError(t *testing.T) {
 			})
 
 			Convey("and the message is committed - we assume any retry logic has occurred within the consumer", func() {
-				So(len(message.CommitCalls()), ShouldEqual, 1)
+				So(message.IsMarked(), ShouldBeTrue)
+				So(message.IsCommitted(), ShouldBeTrue)
+				So(len(message.CommitAndReleaseCalls()), ShouldEqual, 1)
 			})
 		})
 	})
@@ -187,7 +191,7 @@ func waitForMessageToBeCommitted(message *kafkatest.Message) {
 	start := time.Now()
 	timeout := start.Add(time.Millisecond * 500)
 	for {
-		if len(message.CommitCalls()) > 0 {
+		if len(message.CommitAndReleaseCalls()) > 0 {
 			log.Event(ctx, "message has been committed", log.INFO)
 			break
 		}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ONSdigital/dp-api-clients-go v1.30.0
 	github.com/ONSdigital/dp-graph/v2 v2.2.2
 	github.com/ONSdigital/dp-healthcheck v1.0.5
-	github.com/ONSdigital/dp-kafka/v2 v2.0.1
+	github.com/ONSdigital/dp-kafka/v2 v2.1.0
 	github.com/ONSdigital/dp-net v1.0.9
 	github.com/ONSdigital/dp-s3 v1.5.1
 	github.com/ONSdigital/dp-vault v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/ONSdigital/dp-graph/v2 v2.2.2/go.mod h1:K4LIhFcyxB8g7nUG5I5I8x6QVf89x
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
-github.com/ONSdigital/dp-kafka/v2 v2.0.1 h1:ELjFBiZKqtIJUJihDwCOKIaqmVesNOjpkGk/h/R4b4s=
-github.com/ONSdigital/dp-kafka/v2 v2.0.1/go.mod h1:iyDeWxp1QyJJBQ4cOCWuwrwU9iGS9qYbfV7avbcaenI=
+github.com/ONSdigital/dp-kafka/v2 v2.1.0 h1:xYWdTqyS7q7ps5KzmrKAgPvU9//EnioI8nsNv9RU7og=
+github.com/ONSdigital/dp-kafka/v2 v2.1.0/go.mod h1:iyDeWxp1QyJJBQ4cOCWuwrwU9iGS9qYbfV7avbcaenI=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805082802-e518bc287596/go.mod h1:wDVhk2pYosQ1q6PXxuFIRYhYk2XX5+1CeRRnXpSczPY=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805145012-9227a11caddb/go.mod h1:MrSZwDUvp8u1VJEqa+36Gwq4E7/DdceW+BDCvGes6Cs=


### PR DESCRIPTION
### What

- Updated to dp-kafka 2.1.0, which reintroduces CommitAndRelease (at message level)
- Updated accordingly (msg.Commit() -> msg.CommitAndRelease())

### How to review

- Make sure code changes make sense (`CommitAndRelease` implements the same logic that `Commit` did in the dp-kafka v2.0.x)
- Make sure unit tests pass

### Who can review

Anyone
