### PR TITLE
bump dp-kafka to 2.3.1 to get healthcheck TLS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ONSdigital/dp-api-clients-go v1.40.0
 	github.com/ONSdigital/dp-graph/v2 v2.13.1
 	github.com/ONSdigital/dp-healthcheck v1.0.5
-	github.com/ONSdigital/dp-kafka/v2 v2.3.0
+	github.com/ONSdigital/dp-kafka/v2 v2.3.1
 	github.com/ONSdigital/dp-net v1.0.12
 	github.com/ONSdigital/dp-s3 v1.5.1
 	github.com/ONSdigital/dp-vault v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/ONSdigital/dp-graph/v2 v2.13.1/go.mod h1:goNf7IF+hJATF9F8DD8QAHNF38s/
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
-github.com/ONSdigital/dp-kafka/v2 v2.3.0 h1:xnJd/wrfzJPtKOyzRiozokXcdKnUrq51aqcrwQojt4c=
-github.com/ONSdigital/dp-kafka/v2 v2.3.0/go.mod h1:tBbTWqxPEKaUJB9vOGu1sAWaz/L4hbbRvIzeTymjiY0=
+github.com/ONSdigital/dp-kafka/v2 v2.3.1 h1:ZckulUco7eCB3M9d8u1kjiPMRfzGKcvGtAX+CruL5MM=
+github.com/ONSdigital/dp-kafka/v2 v2.3.1/go.mod h1:tBbTWqxPEKaUJB9vOGu1sAWaz/L4hbbRvIzeTymjiY0=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805082802-e518bc287596/go.mod h1:wDVhk2pYosQ1q6PXxuFIRYhYk2XX5+1CeRRnXpSczPY=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805145012-9227a11caddb/go.mod h1:MrSZwDUvp8u1VJEqa+36Gwq4E7/DdceW+BDCvGes6Cs=


### PR DESCRIPTION
### What

get healthcheck to work with TLS kafka - bump dp-kafka version

### How to review

ensure app runs with health

### Who can review

you!
