### PR TITLE
Use Version struct for UsageNotes, cleanup code elsewhere

### DIFF
--- a/csvw/csvw.go
+++ b/csvw/csvw.go
@@ -191,8 +191,8 @@ func (csvw *CSVW) AddNotes(metadata *dataset.Metadata, url string) {
 		}
 	}
 
-	if metadata.DatasetDetails.UsageNotes != nil {
-		for _, u := range *metadata.DatasetDetails.UsageNotes {
+	if metadata.Version.UsageNotes != nil {
+		for _, u := range *metadata.Version.UsageNotes {
 			csvw.Notes = append(csvw.Notes, Note{
 				Type: u.Title,
 				Body: u.Note,

--- a/csvw/csvw_test.go
+++ b/csvw/csvw_test.go
@@ -111,8 +111,6 @@ func TestAddNotes(t *testing.T) {
 						Type:        "correction",
 					},
 				},
-			},
-			DatasetDetails: dataset.DatasetDetails{
 				UsageNotes: &[]dataset.UsageNote{
 					{
 						Note:  "use it this way",
@@ -142,7 +140,7 @@ func TestAddNotes(t *testing.T) {
 					count++
 				}
 
-				for _, a := range *n.DatasetDetails.UsageNotes {
+				for _, a := range *n.Version.UsageNotes {
 					So(csvw.Notes[count].Type, ShouldEqual, a.Title)
 					So(csvw.Notes[count].Body, ShouldEqual, a.Note)
 					So(csvw.Notes[count].Target, ShouldBeEmpty)
@@ -158,7 +156,7 @@ func TestAddNotes(t *testing.T) {
 			Convey("Then the values should be set to the expected fields", func() {
 				So(csvw.Notes, ShouldHaveLength, 2)
 
-				for i, a := range *n.DatasetDetails.UsageNotes {
+				for i, a := range *n.Version.UsageNotes {
 					So(csvw.Notes[i].Type, ShouldEqual, a.Title)
 					So(csvw.Notes[i].Body, ShouldEqual, a.Note)
 					So(csvw.Notes[i].Target, ShouldBeEmpty)
@@ -167,7 +165,7 @@ func TestAddNotes(t *testing.T) {
 		})
 
 		Convey("When there are no usage notes and the AddNotes function is called", func() {
-			n.DatasetDetails.UsageNotes = nil
+			n.Version.UsageNotes = nil
 			csvw.AddNotes(n, fileURL)
 
 			Convey("Then the values should be set to the expected fields", func() {
@@ -182,7 +180,7 @@ func TestAddNotes(t *testing.T) {
 		})
 
 		Convey("When there are no usage notes or and the AddNotes function is called", func() {
-			n.DatasetDetails.UsageNotes = nil
+			n.Version.UsageNotes = nil
 			n.Alerts = nil
 			csvw.AddNotes(n, fileURL)
 

--- a/event/consumer.go
+++ b/event/consumer.go
@@ -138,7 +138,7 @@ func processMessage(ctx context.Context, message kafka.Message, handler Handler,
 	return err
 }
 
-// unmarshal converts a event instance to []byte.
+// unmarshal converts an event instance to []byte.
 func unmarshal(message kafka.Message) (*FilterSubmitted, error) {
 	var event FilterSubmitted
 	err := schema.FilterSubmittedEvent.Unmarshal(message.GetData(), &event)

--- a/event/handler_test.go
+++ b/event/handler_test.go
@@ -1150,7 +1150,7 @@ func TestSortFilter(t *testing.T) {
 				// launched may return the expected error from simulated mongo and exit the loop before
 				// the 3rd go routine runs ...
 				// which means we can not check the value of GetOptionCalls() as elsewhere as it might
-				// return 2 or it might return 3
+				// return 2, or it might return 3
 				// So(len(datasetAPIMock.GetOptionsCalls()), ShouldEqual, 3)
 				So(dbFilter.Dimensions[0].Name, ShouldEqual, "geography")
 				So(dbFilter.Dimensions[1].Name, ShouldEqual, "economicactivity")

--- a/event/producer_test.go
+++ b/event/producer_test.go
@@ -41,7 +41,7 @@ func TestAvroProducer_CSVExported(t *testing.T) {
 		})
 
 		Convey("When CSVExported is called on the event producer", func() {
-			event := &event.CSVExported{
+			csvEvent := &event.CSVExported{
 				DatasetID:  "",
 				InstanceID: "",
 				Edition:    "",
@@ -50,7 +50,7 @@ func TestAvroProducer_CSVExported(t *testing.T) {
 				Filename:   "",
 				RowCount:   0,
 			}
-			err := eventProducer.CSVExported(event)
+			err := eventProducer.CSVExported(csvEvent)
 
 			Convey("The expected event is available on the output channel", func() {
 				log.Info(ctx, "error is:", log.Data{"error": err})
@@ -66,8 +66,8 @@ func TestAvroProducer_CSVExported(t *testing.T) {
 
 // Unmarshal converts observation events to []byte.
 func unmarshal(bytes []byte) *event.CSVExported {
-	event := &event.CSVExported{}
-	err := schema.CSVExportedEvent.Unmarshal(bytes, event)
+	csvEvent := &event.CSVExported{}
+	err := schema.CSVExportedEvent.Unmarshal(bytes, csvEvent)
 	So(err, ShouldBeNil)
-	return event
+	return csvEvent
 }

--- a/file/store.go
+++ b/file/store.go
@@ -100,7 +100,10 @@ func (store *Store) PutFile(ctx context.Context, reader io.Reader, filename stri
 			"name":   filename,
 		})
 
-		psk := createPSK()
+		psk, err := createPSK()
+		if err != nil {
+			return "", err
+		}
 		vaultPath := store.VaultPath + "/" + path.Base(filename)
 		vaultKey := "key"
 
@@ -129,9 +132,9 @@ func (store *Store) PutFile(ctx context.Context, reader io.Reader, filename stri
 	return url.PathUnescape(result.Location)
 }
 
-func createPSK() []byte {
+func createPSK() ([]byte, error) {
 	key := make([]byte, 16)
-	rand.Read(key)
+	_, err := rand.Read(key)
 
-	return key
+	return key, err
 }

--- a/filter/store_test.go
+++ b/filter/store_test.go
@@ -50,14 +50,14 @@ func TestStore_GetFilter(t *testing.T) {
 
 		Convey("When GetFilter is called", func() {
 
-			filter, err := filterStore.GetFilter(ctx, filterOutputID)
+			filterData, err := filterStore.GetFilter(ctx, filterOutputID)
 
 			Convey("The expected filter data is returned", func() {
 				So(err, ShouldBeNil)
 
-				So(filter.FilterID, ShouldEqual, filterOutputID)
-				So(filter.Dimensions[0].Name, ShouldEqual, "Sex")
-				So(filter.Dimensions[0].Options, ShouldResemble, []string{"male"})
+				So(filterData.FilterID, ShouldEqual, filterOutputID)
+				So(filterData.Dimensions[0].Name, ShouldEqual, "Sex")
+				So(filterData.Dimensions[0].Options, ShouldResemble, []string{"male"})
 			})
 
 			Convey("Filter client is called with the valid serviceAuthToken", func() {

--- a/initialise/initialise.go
+++ b/initialise/initialise.go
@@ -99,7 +99,7 @@ func (e *ExternalServiceList) GetObservationStore(ctx context.Context) (observat
 	return
 }
 
-// GetProducer returns a kafka producer, which might no be initialised
+// GetProducer returns a kafka producer, which might not be initialised
 func (e *ExternalServiceList) GetProducer(
 	ctx context.Context,
 	kafkaBrokers []string,

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -20,7 +20,7 @@ type wrappedReader struct {
 }
 
 // New returns a new Reader whose first line can be read without advancing
-// the offset, allowing all of the data to still be read from Read
+// the offset, allowing all the data to still be read from Read
 func New(r io.Reader) *wrappedReader {
 	return &wrappedReader{
 		r: r,


### PR DESCRIPTION
### What

UseageNotes should only be retrieved from Version struct, so thats what the code now does.
Remove name clashes of variables with import names.
Fix unhandled error.
Fix comment typo's.

### How to review

Run tests.
Inspect code changes.

### Who can review

Anyone.
